### PR TITLE
Add GPTLocalhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Your contributions are always welcome!
 - [Taskyon](https://github.com/Xyntopia/taskyon) - Vue3 based Chat UI, integratable in webpages. Focused on "local first" principle. Any OpenAI API compatible endpoint.
 - [QA-Pilot](https://github.com/reid41/QA-Pilot) - An interactive chat app that leverages Ollama(or openAI) models for rapid understanding and navigation of GitHub code repository or compressed file resources
 - [HammerAI](https://www.hammerai.com/desktop) - Simple character-chat interface to run LLMs on Windows, Mac, and Linux. Uses Ollama under the hood and is offline, free to chat, and requires zero configuration.
+- [GPTLocalhost](https://gptlocalhost.com/demo/) - A local Word Add-in for you to use local LLM servers in Microsoft Word. Alternative to "Copilot in Word" and much more affordable.
 
 ## Platforms / full solutions
 


### PR DESCRIPTION
This repo is great and thank you, @0xSage. Can you add [GPTLocalhost (a local Word Add-in)](https://gptlocalhost.com/demo/) so that local LLMs are more accessible to Word users? 